### PR TITLE
Idempotency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Berksfile.lock
 shared_test_repo/
 test/integration
 Gemfile.lock
+coverage

--- a/recipes/minimize_access.rb
+++ b/recipes/minimize_access.rb
@@ -24,6 +24,7 @@ paths = %w(/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin) + node[
 paths.each do |folder|
   execute "remove write permission from #{folder}" do
     command "chmod go-w -R #{folder}"
+    not_if "find #{folder}  -perm -go+w -type f | wc -l | egrep '^0$'"
   end
 end
 

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -27,6 +27,13 @@ describe 'os-hardening::default' do
       # therefore we set it manually here
       node.set['sysctl']['conf_dir'] = '/etc/sysctl.d'
       node.set['cpu']['0']['vendor_id'] = 'GenuineIntel'
+      node.set['env']['extra_user_paths'] = []
+
+      paths = %w(/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin) + node['env']['extra_user_paths']
+      paths.each do |folder|
+        stub_command("find #{folder}  -perm -go+w -type f | wc -l | egrep '^0$'").and_return(false)
+      end
+
     end.converge(described_recipe)
   end
 


### PR DESCRIPTION
Various resources get executed even if there is no change needed. While this is fine it 'pollutes' chef's statistics about updated resources e.g. when someone is monitoring those data using a chef-handler will see changes/updates on each converge:

e.g. within
https://github.com/TelekomLabs/chef-os-hardening/blob/master/recipes/minimize_access.rb

I would probably split "group" and "other"  into separate resources and guard them by "only_if" filters using "find #{folder} -perm -g+w " and "find #{folder} -perm -o+w "




