### PR TITLE
Run GPGCheck against RedHatNetwork plugin

### DIFF
--- a/recipes/yum.rb
+++ b/recipes/yum.rb
@@ -31,6 +31,9 @@ ruby_block 'check package signature in repo files' do
 
     Dir.glob('/etc/yum.repos.d/*').each do |file|
       GPGCheck.check(file)
+    
+    rhn_conf = '/etc/yum/pluginconf.d/rhnplugin.conf'
+    GPGCheck.check(rhn_conf) if File.file?(rhn_conf)
     end
   end
   action :run


### PR DESCRIPTION
If RHN plugin is installed, RHN registered channels ignore yum.comf and instead use RHN config at /etc/yum/pluginconf.d/rhnplugin.conf
This check should be performed on this conf file as well if it exists.

This needs to be done on any RedHat Linux systems registered to a Satellite or the RedHat Network itself. This also must be done to RedHat/CentOS/Fedora systems registered to a spacewalk server.