### PR TITLE
GPGCheck rhnplugin.conf

### DIFF
--- a/recipes/yum.rb
+++ b/recipes/yum.rb
@@ -31,10 +31,10 @@ ruby_block 'check package signature in repo files' do
 
     Dir.glob('/etc/yum.repos.d/*').each do |file|
       GPGCheck.check(file)
+    end
     
     rhn_conf = '/etc/yum/pluginconf.d/rhnplugin.conf'
     GPGCheck.check(rhn_conf) if File.file?(rhn_conf)
-    end
   end
   action :run
 end

--- a/recipes/yum.rb
+++ b/recipes/yum.rb
@@ -32,7 +32,7 @@ ruby_block 'check package signature in repo files' do
     Dir.glob('/etc/yum.repos.d/*').each do |file|
       GPGCheck.check(file)
     end
-    
+
     rhn_conf = '/etc/yum/pluginconf.d/rhnplugin.conf'
     GPGCheck.check(rhn_conf) if File.file?(rhn_conf)
   end

--- a/recipes/yum.rb
+++ b/recipes/yum.rb
@@ -31,6 +31,9 @@ ruby_block 'check package signature in repo files' do
 
     Dir.glob('/etc/yum.repos.d/*').each do |file|
       GPGCheck.check(file)
+    
+    rhn_conf = '/etc/yum/pluginconf.d/rhnplugin.conf'
+    GPGCheck.check(rhn_conf) if File.file?(rhn_conf)
     end
   end
   action :run


### PR DESCRIPTION
If RHN plugin is installed, RHN registered channels ignore yum.comf and instead use RHN config at /etc/yum/pluginconf.d/rhnplugin.conf
This check should be performed on this conf file as well if it exists.

This must be preformed on any system connecting to RedHat Network, a RedHat Satellite, or a Spacewalk server