### PR TITLE
fix SUID/SGID bit cleaning API spelling (unkown -> unknown)

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -7,15 +7,15 @@ See reference documentation [here](http://www.telekom.com/static/-/155996/7/tech
 
 #### 3.21 Unix Requirements v1.2 
 
-| Requirement |                      Configuration                       |
-|-------------|----------------------------------------------------------|
-| 6           | active by default                                        |
-| 9           | active by default                                        |
-| 11          | active by default                                        |
-| 10          | active by default                                        |
-| 14          | `['security']['suid_sgid']['remove_from_unkown'] = true` |
-| 16          | active by default                                        |
-| 17          | active by default                                        |
+| Requirement |                      Configuration                        |
+|-------------|-----------------------------------------------------------|
+| 6           | active by default                                         |
+| 9           | active by default                                         |
+| 11          | active by default                                         |
+| 10          | active by default                                         |
+| 14          | `['security']['suid_sgid']['remove_from_unknown'] = true` |
+| 16          | active by default                                         |
+| 17          | active by default                                         |
 
 #### 3.01 Technical Baseline Security for IT/NT Systems 
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ We deprecated `sysctl` version before `0.6.0`. Future versions of this cookbook 
   a list of paths which should have their SUID/SGID bits removed
 * `['security']['suid_sgid']['whitelist'] = []`
   a list of paths which should not have their SUID/SGID bits altered
-* `['security']['suid_sgid']['remove_from_unkown'] = false`
+* `['security']['suid_sgid']['remove_from_unknown'] = false`
   true if you want to remove SUID/SGID bits from any file, that is not explicitly configured in a `blacklist`. This will make every Chef run search through the mounted filesystems looking for SUID/SGID bits that are not configured in the default and user blacklist. If it finds an SUID/SGID bit, it will be removed, unless this file is in your `whitelist`.
-* `['security']['suid_sgid']['dry_run_on_unkown'] = false`
-  like `remove_from_unknown` above, only that SUID/SGID bits aren't removed. It will still search the filesystems to look for SUID/SGID bits but it will only print them in your log. This option is only ever recommended, when you first configure `remove_from_unkown` for SUID/SGID bits, so that you can see the files that are being changed and make adjustments to your `whitelist` and `blacklist`.
+* `['security']['suid_sgid']['dry_run_on_unknown'] = false`
+  like `remove_from_unknown` above, only that SUID/SGID bits aren't removed.
+  It will still search the filesystems to look for SUID/SGID bits but it will only print them in your log. This option is only ever recommended, when you first configure `remove_from_unknown` for SUID/SGID bits, so that you can see the files that are being changed and make adjustments to your `whitelist` and `blacklist`.
 * `['security']['packages']['clean']  = true` 
   removes packages with known issues. See section packages.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -51,7 +51,7 @@ EOF
 cat > solo.json <<EOF
 {
     "security" : {"suid_sgid": {
-        "remove_from_unkown" : true,
+        "remove_from_unknown" : true,
         "system_whitelist" : []
         }
     },

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -75,8 +75,8 @@ default['security']['suid_sgid']['blacklist']          = []
 default['security']['suid_sgid']['whitelist']          = []
 # if this is true, remove any suid/sgid bits from files that were not in the
 # whitelist
-default['security']['suid_sgid']['remove_from_unkown'] = false
-default['security']['suid_sgid']['dry_run_on_unkown']  = false
+default['security']['suid_sgid']['remove_from_unknown'] = false
+default['security']['suid_sgid']['dry_run_on_unknown']  = false
 
 # remove packages with known issues
 default['security']['packages']['clean']               = true

--- a/libraries/suid_sgid.rb
+++ b/libraries/suid_sgid.rb
@@ -52,7 +52,7 @@ class Chef
           end
       end
 
-      def self.remove_suid_sgid_from_unkown(whitelist = [], root = '/', dry_run = false)
+      def self.remove_suid_sgid_from_unknown(whitelist = [], root = '/', dry_run = false)
         all_suid_sgid_files = find_all_suid_sgid_files(root).select do|file|
           in_whitelist = whitelist.include?(file)
           Chef::Log.info "suid_sgid: Whitelisted file '#{file}', not altering SUID/SGID bit" if in_whitelist && !dry_run

--- a/recipes/suid_sgid.rb
+++ b/recipes/suid_sgid.rb
@@ -45,4 +45,4 @@ ruby_block 'remove_suid_from_unknown' do
     SuidSgid.remove_suid_sgid_from_unknown(whitelist, root, dry_run)
   end
 end if node['security']['suid_sgid']['remove_from_unknown'] ||
-    node['security']['suid_sgid']['dry_run_on_unknown']
+       node['security']['suid_sgid']['dry_run_on_unknown']

--- a/recipes/suid_sgid.rb
+++ b/recipes/suid_sgid.rb
@@ -29,7 +29,7 @@ blacklist = (sb - w + b).uniq
 whitelist = (sw - b + w).uniq
 
 # root    = "/"
-dry_run   = node['security']['suid_sgid']['dry_run_on_unkown']
+dry_run   = node['security']['suid_sgid']['dry_run_on_unknown']
 root      = node['env']['root_path']
 
 # walk the blacklist and remove suid and sgid bits from these items
@@ -39,9 +39,10 @@ ruby_block 'remove_suid_from_blacklists' do
   end
 end
 
-# remove suid bits from unkown, if desired
-ruby_block 'remove_suid_from_unkown' do
+# remove suid bits from unknown, if desired
+ruby_block 'remove_suid_from_unknown' do
   block do
-    SuidSgid.remove_suid_sgid_from_unkown(whitelist, root, dry_run)
+    SuidSgid.remove_suid_sgid_from_unknown(whitelist, root, dry_run)
   end
-end if node['security']['suid_sgid']['remove_from_unkown'] || node['security']['suid_sgid']['dry_run_on_unkown']
+end if node['security']['suid_sgid']['remove_from_unknown'] ||
+    node['security']['suid_sgid']['dry_run_on_unknown']


### PR DESCRIPTION
Having a misspelling in an API is especially awkward, since fixing the spelling could break the code. But I think this is obscure enough that nobody is likely to be using it already...
